### PR TITLE
Bugfix/ordering when insert positionable

### DIFF
--- a/src/isometric_server.cpp
+++ b/src/isometric_server.cpp
@@ -71,7 +71,8 @@ void IsometricServer::delete_space(const RID &rid) {
     worlds_owner.free(rid);
 }
 
-RID IsometricServer::register_isometric_element(const RID space_rid, RID p_canvas_item, bool p_is_dynamic) {
+RID IsometricServer::register_isometric_element(const RID space_rid, RID p_canvas_item, bool p_is_dynamic,
+                                                const AABB& aabb) {
     data::IsometricSpace* space{worlds_owner.getornull(space_rid)};
     if (!space) {
         WARN_PRINT(vformat("This is not a valid isometric space RID: %s", space_rid.get_id()))
@@ -82,6 +83,7 @@ RID IsometricServer::register_isometric_element(const RID space_rid, RID p_canva
     isometric_element->visual_rid = p_canvas_item;
     isometric_element->is_dynamic = p_is_dynamic;
     isometric_element->world = space_rid;
+    isometric_element->aabb = aabb;
     isometric_element->z_size = 1;
 
     if (!p_is_dynamic) {

--- a/src/isometric_server.cpp
+++ b/src/isometric_server.cpp
@@ -21,7 +21,7 @@ IsometricServer* IsometricServer::get_instance() {
 }
 
 void IsometricServer::iteration(void* p_udata) {
-    uint64_t msdelay = 3000;
+    static uint64_t msdelay{get_ms_delay()};
 
     auto* server{reinterpret_cast<IsometricServer*>(p_udata)};
 
@@ -49,8 +49,13 @@ void IsometricServer::iteration(void* p_udata) {
 
         OS::get_singleton()->delay_usec(msdelay * 1000);
     }
+}
 
-
+uint64_t IsometricServer::get_ms_delay() {
+    if (Engine::get_singleton()->is_editor_hint()) {
+        return 33;
+    }
+    return 3000;
 }
 
 RID IsometricServer::create_space() {

--- a/src/isometric_server.h
+++ b/src/isometric_server.h
@@ -19,6 +19,7 @@ private:
 
     void render_isometric_element(data::IsometricElement* data);
     static void iteration(void* p_udata);
+    static uint64_t get_ms_delay();
 
 public:
     IsometricServer();

--- a/src/isometric_server.h
+++ b/src/isometric_server.h
@@ -42,7 +42,7 @@ public:
 
     const data::IsometricParameters* get_space_configuration_from_element(const RID element_rid);
 
-    RID register_isometric_element(const RID space_rid, RID p_canvas_item, bool p_is_dynamic);
+    RID register_isometric_element(const RID space_rid, RID p_canvas_item, bool p_is_dynamic, const AABB& aabb);
 
     void unregister_isometric_element(const RID space_rid, const RID rid);
 

--- a/src/node/isometric_map.cpp
+++ b/src/node/isometric_map.cpp
@@ -111,8 +111,8 @@ void IsometricMap::add_positionable_as_child(int positionable_id, const Vector3&
             )
         }
     ) {
-        add_child(positionable);
         positionable->set_local_position_3d(position);
+        add_child(positionable);
 
         instances_grid_3d.insert_box({position, positionable->get_size()}, positionable);
     }

--- a/src/node/isometric_positionable.cpp
+++ b/src/node/isometric_positionable.cpp
@@ -26,7 +26,7 @@ void IsometricPositionable::_enter_tree() {
                 world = positionable->world;
                 world_owner = false;
                 self = IsometricServer::get_instance()->register_isometric_element(world, this->get_canvas_item(),
-                                                                                   is_dynamic);
+                                                                                   is_dynamic, {get_global_position_3d(), size});
                 update_position();
                 return;
             }
@@ -38,7 +38,7 @@ void IsometricPositionable::_enter_tree() {
 
 
     self = IsometricServer::get_instance()->register_isometric_element(world, this->get_canvas_item(),
-                                                                       is_dynamic);
+                                                                       is_dynamic, {get_global_position_3d(), size});
     update_position();
 }
 
@@ -95,10 +95,12 @@ Vector3 IsometricPositionable::get_local_position_3d() const {
 
 void IsometricPositionable::set_local_position_3d(Vector3 p_local) {
     local_position = p_local;
-
-    IsometricServer::get_instance()->set_isometric_element_position(self, get_global_position_3d());
-
-    update_position();
+    if(self.is_valid()) {
+        IsometricServer::get_instance()->set_isometric_element_position(self, get_global_position_3d());
+    }
+    if (world.is_valid()) {
+        update_position();
+    }
 }
 
 Vector3 IsometricPositionable::get_global_position_3d() const {
@@ -117,7 +119,9 @@ Vector3 IsometricPositionable::get_size() const {
 
 void IsometricPositionable::set_size(Vector3 s) {
     size = s;
-    IsometricServer::get_instance()->set_isometric_element_size(self, size);
+    if(self.is_valid()) {
+        IsometricServer::get_instance()->set_isometric_element_size(self, size);
+    }
     set_outline_drawer(Color(1., 0., 0.), 3);
 }
 


### PR DESCRIPTION
This fixes wrong ordering when placing positionable in map by providing position and size of positionable to `IsometricServer` when registering a tile.