### PR TITLE
feat: Preserve map's last edited layer in its metadata for ergonomy

### DIFF
--- a/src/editor/commands/revert_command.h
+++ b/src/editor/commands/revert_command.h
@@ -12,7 +12,7 @@ namespace editor {
         public:
             void redo() override;
             void undo() override;
-            void set_context_node(TContextNode* p_context_node);
+            void set_context_node(TContextNode* p_context_node) override;
 
             void set_reverse_command(Ref<Command<TContextNode>> p_reverse_command);
 

--- a/src/editor/inspector/layers_editor.h
+++ b/src/editor/inspector/layers_editor.h
@@ -2,11 +2,12 @@
 #define ISOMETRIC_MAPS_LAYERS_EDITOR_H
 
 #ifdef TOOLS_ENABLED
-#include "scene/gui/box_container.h"
-#include "scene/gui/line_edit.h"
-#include "scene/gui/button.h"
-#include "scene/gui/check_box.h"
-#include "scene/gui/grid_container.h"
+#include "node/isometric_map.h"
+#include <scene/gui/box_container.h>
+#include <scene/gui/button.h>
+#include <scene/gui/check_box.h>
+#include <scene/gui/grid_container.h>
+#include <scene/gui/line_edit.h>
 
 namespace editor {
     namespace inspector {
@@ -73,12 +74,15 @@ namespace editor {
             uint32_t get_layer_id() const;
             void set_layer_id(uint32_t p_layer_id);
 
+            void on_pressed();
+
             CurrentLayerCheckBox();
 
         private:
             uint32_t layer_id;
 
         protected:
+            void _notification(int notif);
             static void _bind_methods();
         };
     }

--- a/src/node/isometric_map.h
+++ b/src/node/isometric_map.h
@@ -14,6 +14,10 @@ namespace node {
         static constexpr uint32_t DEFAULT_LAYER_ID = 0;
         static constexpr uint32_t NO_LAYER_ID = 0xffffffff;
 
+#ifdef TOOLS_ENABLED
+        static constexpr const char* LAST_EDITED_LAYER_META_NAME = "_LAST_EDITED_LAYER";
+#endif
+
     private:
         containers::Grid3D<int, resource::PositionableSet::NONE_POSITIONABLE_ID> grid_3d;
         containers::Grid3D<uint32_t, DEFAULT_LAYER_ID> layers_grid_3d;


### PR DESCRIPTION
This keeps last edited layer in `node::IsometricMap` metadata.  
This enable to keep layers when switching between maps and also set selected layer to last edited when reopening the map scene.