### PR TITLE
enh: add spatial partitioning to drag and drop command emitter

### DIFF
--- a/src/editor/commands/emitters/drag_and_drop_command_emitter.cpp
+++ b/src/editor/commands/emitters/drag_and_drop_command_emitter.cpp
@@ -82,22 +82,10 @@ Vector<Ref<editor::commands::Command<node::IsometricMap>>> DragAndDropCommandEmi
           MIN(former_limit_position.z, static_cast<int>(limit_position.z))
         };
 
-        Vector3i end_check_position {
-          MAX(former_limit_position.x, static_cast<int>(limit_position.x)),
-          MAX(former_limit_position.y, static_cast<int>(limit_position.y)),
-          MAX(former_limit_position.z, static_cast<int>(limit_position.z))
-        };
-
         for (Chunk* chunk : chunks) {
             if (chunk->last_position.x < begin_check_position.x &&
                 chunk->last_position.y < begin_check_position.y &&
                 chunk->last_position.z < begin_check_position.z) {
-                continue;
-            }
-
-            if (chunk->begin_position.x > end_check_position.x &&
-                chunk->begin_position.y > end_check_position.y &&
-                chunk->begin_position.z > end_check_position.z) {
                 continue;
             }
 

--- a/src/editor/commands/emitters/drag_and_drop_command_emitter.cpp
+++ b/src/editor/commands/emitters/drag_and_drop_command_emitter.cpp
@@ -8,6 +8,8 @@
 
 using namespace editor::commands::emitters;
 
+static constexpr const uint32_t CHUNK_SIDE_SIZE {10};
+
 Vector<Ref<editor::commands::Command<node::IsometricMap>>> DragAndDropCommandEmitter::from_gui_input_to_command_impl([[maybe_unused]] Ref<InputEventMouse> p_event
 ) {// NOLINT(performance-unnecessary-value-param)
     Vector<Ref<editor::commands::Command<node::IsometricMap>>> commands;
@@ -42,12 +44,15 @@ Vector<Ref<editor::commands::Command<node::IsometricMap>>> DragAndDropCommandEmi
     }
 
     if (Input::get_singleton()->is_mouse_button_pressed(MouseButton::LEFT)) {
+        Vector3i former_limit_position;
+
         if (is_activated) {
             AABB real_aabb {_calculate_real_aabb(initial_position, mouse_position, positionable_size)};
             if (!map->is_aabb_in_map(real_aabb) || map->is_overlapping(real_aabb) || !isometric_editor_plugin->is_aabb_in_view_limiters(real_aabb)) {
                 return commands;
             }
 
+            former_limit_position = limit_position;
             limit_position = mouse_position;
         } else {
             AABB real_aabb {_calculate_real_aabb(mouse_position, mouse_position, positionable_size)};
@@ -55,55 +60,145 @@ Vector<Ref<editor::commands::Command<node::IsometricMap>>> DragAndDropCommandEmi
                 return commands;
             }
 
+            former_limit_position = mouse_position;
             initial_position = mouse_position;
             limit_position = mouse_position;
         }
+        
+        Vector<Chunk*> chunks {
+          _get_chunks_for_position_interval(
+            initial_position,
+            {
+              MAX(limit_position.x, former_limit_position.x),
+              MAX(limit_position.y, former_limit_position.y),
+              MAX(limit_position.z, former_limit_position.z)
+            }
+          )
+        };
 
-        Vector<Vector3> all_positions {_calculate_positionables_positions(initial_position, limit_position, positionable_size)};
+        Vector3i begin_check_position {
+          MIN(former_limit_position.x, static_cast<int>(limit_position.x)),
+          MIN(former_limit_position.y, static_cast<int>(limit_position.y)),
+          MIN(former_limit_position.z, static_cast<int>(limit_position.z))
+        };
 
-        int new_size = all_positions.size();
+        Vector3i end_check_position {
+          MAX(former_limit_position.x, static_cast<int>(limit_position.x)),
+          MAX(former_limit_position.y, static_cast<int>(limit_position.y)),
+          MAX(former_limit_position.z, static_cast<int>(limit_position.z))
+        };
 
-        if (preview_node->get_parent() == map) { map->remove_child(preview_node); }
+        for (Chunk* chunk : chunks) {
+            if (chunk->last_position.x < begin_check_position.x &&
+                chunk->last_position.y < begin_check_position.y &&
+                chunk->last_position.z < begin_check_position.z) {
+                continue;
+            }
 
-        // Shrink, remove and delete excess nodes.
-        _clear_current_preview_nodes(new_size);
+            if (chunk->begin_position.x > end_check_position.x &&
+                chunk->begin_position.y > end_check_position.y &&
+                chunk->begin_position.z > end_check_position.z) {
+                continue;
+            }
 
-        // Existing nodes are reused.
-        for (int i = 0; i < current_preview_nodes.size(); ++i) {
-            node::IsometricPositionable* preview_positionable {current_preview_nodes[i]};
-            preview_positionable->set_modulate(Color(1, 1, 1, 0.5));
-            preview_positionable->set_local_position_3d(all_positions[i]);
-            preview_node->add_child(preview_positionable);
+            Vector3 chunk_initial_position {
+              MAX(chunk->begin_position.x, initial_position.x),
+              MAX(chunk->begin_position.y, initial_position.y),
+              MAX(chunk->begin_position.z, initial_position.z)
+            };
+            Vector3 chunk_limit_position {
+              MIN(chunk->last_position.x, limit_position.x),
+              MIN(chunk->last_position.y, limit_position.y),
+              MIN(chunk->last_position.z, limit_position.z)
+            };
+
+            Vector<Vector3> all_positions;
+
+            if (chunk_initial_position.x <= chunk_limit_position.x &&
+                chunk_initial_position.y <= chunk_limit_position.y &&
+                chunk_initial_position.z <= chunk_limit_position.z) {
+                all_positions = _calculate_positionables_positions(chunk_initial_position, chunk_limit_position, positionable_size);
+            }
+
+            int new_size = all_positions.size();
+
+            Node* preview_node {chunk->preview_node};
+            if (preview_node->get_parent() == map) { map->remove_child(preview_node); }
+
+            // Shrink, remove and delete excess nodes.
+            _clear_current_preview_nodes(chunk, new_size);
+
+            Vector<node::IsometricPositionable*>& current_preview_nodes {chunk->current_preview_nodes};
+
+            // Existing nodes are reused.
+            for (int i = 0; i < current_preview_nodes.size(); ++i) {
+                node::IsometricPositionable* preview_positionable {current_preview_nodes[i]};
+                preview_positionable->set_modulate(Color(1, 1, 1, 0.5));
+                preview_positionable->set_local_position_3d(all_positions[i]);
+                preview_node->add_child(preview_positionable);
+            }
+
+            // New nodes are added if the size grew.
+            for (int i = current_preview_nodes.size(); i < new_size; ++i) {
+                node::IsometricPositionable* preview_positionable {
+                  Object::cast_to<node::IsometricPositionable>(
+                    map->get_positionable_set()->get_positionable_scene_for_id(selected_tile_id)->instantiate()
+                  )
+                };
+                current_preview_nodes.push_back(preview_positionable);
+                preview_positionable->set_modulate(Color(1, 1, 1, 0.5));
+                preview_positionable->set_local_position_3d(all_positions[i]);
+                preview_node->add_child(preview_positionable);
+            }
+
+            map->add_child(preview_node);
         }
-
-        // New nodes are added if the size grew.
-        for (int i = current_preview_nodes.size(); i < new_size; ++i) {
-            node::IsometricPositionable* preview_positionable {Object::cast_to<node::IsometricPositionable>(
-              map->get_positionable_set()->get_positionable_scene_for_id(selected_tile_id)->instantiate()
-            )};
-            current_preview_nodes.push_back(preview_positionable);
-            preview_positionable->set_modulate(Color(1, 1, 1, 0.5));
-            preview_positionable->set_local_position_3d(all_positions[i]);
-            preview_node->add_child(preview_positionable);
-        }
-
-        map->add_child(preview_node);
 
         return commands;
     } else if (is_activated) {
-        map->remove_child(preview_node);
-        _clear_current_preview_nodes(0);
+        for (const KeyValue<Vector2i, Chunk*>& item : preview_chunks) {
+            Chunk* chunk {item.value};
 
-        Vector<Vector3> all_positions {_calculate_positionables_positions(initial_position, limit_position, positionable_size)};
+            Node* preview_node {chunk->preview_node};
+            if (preview_node->get_parent() == map) { map->remove_child(preview_node); }
+            _clear_current_preview_nodes(chunk, 0);
 
-        for (Vector3 position : all_positions) {
-            Ref<editor::commands::AddPositionableCommand> add_command;
-            add_command.instantiate();
-            add_command->set_aabb({position, positionable_size});
-            add_command->set_positionable_id(selected_tile_id);
-            add_command->set_layer_id(IsometricEditorPlugin::get_instance()->get_selected_layer());
-            commands.push_back(add_command);
+            Vector3 chunk_initial_position {
+              MAX(chunk->begin_position.x, initial_position.x),
+              MAX(chunk->begin_position.y, initial_position.y),
+              MAX(chunk->begin_position.z, initial_position.z)
+            };
+            Vector3 chunk_limit_position {
+              MIN(chunk->last_position.x, limit_position.x),
+              MIN(chunk->last_position.y, limit_position.y),
+              MIN(chunk->last_position.z, limit_position.z)
+            };
+
+            if (chunk_initial_position.x > chunk_limit_position.x ||
+                chunk_initial_position.y > chunk_limit_position.y ||
+                chunk_initial_position.z > chunk_limit_position.z) {
+                continue;
+            }
+
+            Vector<Vector3> all_positions {_calculate_positionables_positions(chunk_initial_position, chunk_limit_position, positionable_size)};
+
+            for (Vector3 position : all_positions) {
+                Ref<editor::commands::AddPositionableCommand> add_command;
+                add_command.instantiate();
+                add_command->set_aabb({position, positionable_size});
+                add_command->set_positionable_id(selected_tile_id);
+                add_command->set_layer_id(IsometricEditorPlugin::get_instance()->get_selected_layer());
+                commands.push_back(add_command);
+            }
         }
+
+        for (KeyValue<Vector2i, Chunk*>& item : preview_chunks) {
+            Chunk* chunk {item.value};
+            memdelete(chunk->preview_node);
+            delete chunk;
+        }
+
+        preview_chunks.clear();
 
         initial_position = Vector3(-1, -1, -1);
         limit_position = Vector3(-1, -1, -1);
@@ -112,25 +207,26 @@ Vector<Ref<editor::commands::Command<node::IsometricMap>>> DragAndDropCommandEmi
     return commands;
 }
 
-void DragAndDropCommandEmitter::_clear_current_preview_nodes(int new_size) {
-    if (IsometricEditorPlugin* isometric_editor_plugin = IsometricEditorPlugin::get_instance()) {
-        node::IsometricMap* map {isometric_editor_plugin->get_selected_map()};
-
-        // Only remove but not delete nodes in the new range
-        for (int i = 0; i < MIN(new_size, current_preview_nodes.size()); ++i) {
-            if (node::IsometricPositionable* current_preview_node = current_preview_nodes[i]) {
-                preview_node->remove_child(current_preview_node);
-            }
+void DragAndDropCommandEmitter::_clear_current_preview_nodes(Chunk* p_chunk, int new_size) {
+    Vector<node::IsometricPositionable*>& current_preview_nodes {p_chunk->current_preview_nodes};
+    Node* preview_node {p_chunk->preview_node};
+    
+    // Only remove but not delete nodes in the new range
+    for (int i = 0; i < MIN(new_size, current_preview_nodes.size()); ++i) {
+        if (node::IsometricPositionable* current_preview_node = current_preview_nodes[i]) {
+            preview_node->remove_child(current_preview_node);
         }
-        // Remove and delete excess nodes.
-        for (int i = new_size; i < current_preview_nodes.size(); ++i) {
-            if (node::IsometricPositionable* current_preview_node = current_preview_nodes[i]) {
-                preview_node->remove_child(current_preview_node);
-                memdelete(current_preview_node);
-            }
-        }
-        if (new_size < current_preview_nodes.size()) { current_preview_nodes.resize(new_size); }
     }
+
+    // Remove and delete excess nodes.
+    for (int i = new_size; i < current_preview_nodes.size(); ++i) {
+        if (node::IsometricPositionable* current_preview_node = current_preview_nodes[i]) {
+            preview_node->remove_child(current_preview_node);
+            memdelete(current_preview_node);
+        }
+    }
+
+    if (new_size < current_preview_nodes.size()) { current_preview_nodes.resize(new_size); }
 }
 
 AABB DragAndDropCommandEmitter::_calculate_real_aabb(const Vector3& initial_position, const Vector3& limit_position, const Vector3& positionable_size) {
@@ -205,17 +301,122 @@ Vector<Vector3> DragAndDropCommandEmitter::_calculate_positionables_positions(
     return r_ret;
 }
 
+Vector<DragAndDropCommandEmitter::Chunk*> DragAndDropCommandEmitter::_get_chunks_for_position_interval(const Vector3& p_initial_position, const Vector3& p_target_position) {
+    Vector<DragAndDropCommandEmitter::Chunk*> result;
+
+    Vector2i initial_chunk_position {_get_chunk_position(p_initial_position)};
+    Vector2i target_chunk_position {_get_chunk_position(p_target_position)};
+
+    Vector2i difference {target_chunk_position - initial_chunk_position};
+    Vector2i difference_sign {difference.sign()};
+
+    Vector2i current_position {initial_chunk_position};
+
+    bool is_only_one_on_x {current_position.x == target_chunk_position.x};
+    bool is_only_one_on_y {current_position.y == target_chunk_position.y};
+
+    while (current_position.x != target_chunk_position.x + difference_sign.x || is_only_one_on_x) {
+        current_position.y = initial_chunk_position.y;
+        while (current_position.y != target_chunk_position.y + difference_sign.y || is_only_one_on_y) {
+            result.append(_get_or_create_chunks_for_position(current_position));
+
+            if (is_only_one_on_y) {
+                break;
+            }
+
+            current_position += Vector2i(0, difference_sign.y);
+        }
+
+        if (is_only_one_on_x) {
+            break;
+        }
+        
+        current_position += Vector2i(difference_sign.x, 0);
+    }
+
+    return result;
+}
+
+Vector2i DragAndDropCommandEmitter::_get_chunk_position(const Vector3& p_position) {
+    Vector2i chunk_position;
+
+    switch (
+      IsometricEditorPlugin::get_instance()->get_editor_plane_for_map(
+                                             IsometricEditorPlugin::get_instance()->get_selected_map(),
+                                             EditorPlane::PlaneType::EDITOR_DRAWER
+      ).get_axis()
+    ) {
+        case Vector3::AXIS_X:
+            chunk_position = (Vector2(p_position.y, p_position.z) / CHUNK_SIDE_SIZE).floor();
+            break;
+        case Vector3::AXIS_Y:
+            chunk_position = (Vector2(p_position.x, p_position.z) / CHUNK_SIDE_SIZE).floor();
+            break;
+        case Vector3::AXIS_Z:
+            chunk_position = (Vector2(p_position.x, p_position.y) / CHUNK_SIDE_SIZE).floor();
+            break;
+    }
+
+    return chunk_position;
+}
+
+DragAndDropCommandEmitter::Chunk* DragAndDropCommandEmitter::_get_or_create_chunks_for_position(const Vector2i& p_position) {
+    if (DragAndDropCommandEmitter::Chunk** chunk {preview_chunks.getptr(p_position)}) {
+        return *chunk;
+    }
+    
+    DragAndDropCommandEmitter::Chunk* chunk {new Chunk()};
+    chunk->current_preview_nodes = Vector<node::IsometricPositionable*>();
+    chunk->preview_node = memnew(Node);
+
+    EditorPlane& editor_drawer_plane = IsometricEditorPlugin::get_instance()->get_editor_plane_for_map(
+      IsometricEditorPlugin::get_instance()->get_selected_map(),
+      EditorPlane::PlaneType::EDITOR_DRAWER
+    );
+    switch (editor_drawer_plane.get_axis()
+    ) {
+        case Vector3::AXIS_X:
+            chunk->begin_position = Vector3i(
+              editor_drawer_plane.get_position(),
+              static_cast<int>(p_position.x * CHUNK_SIDE_SIZE),
+              static_cast<int>(p_position.y * CHUNK_SIDE_SIZE)
+            );
+            chunk->last_position = chunk->begin_position + Vector3i(0, CHUNK_SIDE_SIZE - 1, CHUNK_SIDE_SIZE - 1);
+            break;
+        case Vector3::AXIS_Y:
+            chunk->begin_position = Vector3i(
+              static_cast<int>(p_position.x * CHUNK_SIDE_SIZE),
+              editor_drawer_plane.get_position(),
+              static_cast<int>(p_position.y * CHUNK_SIDE_SIZE)
+            );
+            chunk->last_position = chunk->begin_position + Vector3i(CHUNK_SIDE_SIZE - 1, 0, CHUNK_SIDE_SIZE - 1);
+            break;
+        case Vector3::AXIS_Z:
+            chunk->begin_position = Vector3i(
+              static_cast<int>(p_position.x * CHUNK_SIDE_SIZE),
+              static_cast<int>(p_position.y * CHUNK_SIDE_SIZE),
+              editor_drawer_plane.get_position()
+            );
+            chunk->last_position = chunk->begin_position + Vector3i(CHUNK_SIDE_SIZE - 1, CHUNK_SIDE_SIZE - 1, 0);
+            break;
+    }
+
+    return preview_chunks.insert(p_position, chunk)->value;
+}
+
 DragAndDropCommandEmitter::DragAndDropCommandEmitter() :
   CommandEmitter(),
-  current_preview_nodes(),
   initial_position(-1, -1, -1),
-  limit_position(-1, -1, -1),
-  preview_node(memnew(Node)) {}
+  limit_position(-1, -1, -1) {}
 
 DragAndDropCommandEmitter::~DragAndDropCommandEmitter() {
-    _clear_current_preview_nodes(0);
-    memdelete(preview_node);
-    preview_node = nullptr;
+    for (KeyValue<Vector2i, Chunk*>& item : preview_chunks) {
+        Chunk* chunk {item.value};
+        _clear_current_preview_nodes(chunk, 0);
+        memdelete(chunk->preview_node);
+        delete chunk;
+    }
+    preview_chunks.clear();
 }
 
 #endif

--- a/src/editor/commands/emitters/drag_and_drop_command_emitter.h
+++ b/src/editor/commands/emitters/drag_and_drop_command_emitter.h
@@ -19,20 +19,29 @@ namespace editor {
                 ~DragAndDropCommandEmitter();
 
             private:
-                Vector<node::IsometricPositionable*> current_preview_nodes;
+                struct Chunk {
+                    Vector<node::IsometricPositionable*> current_preview_nodes;
+                    Node* preview_node;
+                    Vector3i begin_position;
+                    Vector3i last_position;
+                };
 
                 Vector3 initial_position;
                 Vector3 limit_position;
 
-                Node* preview_node;
+                HashMap<Vector2i, Chunk*> preview_chunks;
 
                 Vector<Ref<Command<node::IsometricMap>>> from_gui_input_to_command_impl([[maybe_unused]] Ref<InputEventMouse> p_event);
 
-                void _clear_current_preview_nodes(int new_size);
+                static void _clear_current_preview_nodes(Chunk* p_chunk, int new_size);
 
                 static AABB _calculate_real_aabb(const Vector3& initial_position, const Vector3& limit_position, const Vector3& positionable_size);
 
                 static Vector<Vector3> _calculate_positionables_positions(const Vector3& initial_position, const Vector3& limit_position, const Vector3& positionable_size);
+
+                Vector<Chunk*> _get_chunks_for_position_interval(const Vector3& p_initial_position, const Vector3& p_target_position);
+                static Vector2i _get_chunk_position(const Vector3& p_position);
+                Chunk* _get_or_create_chunks_for_position(const Vector2i& p_position);
             };
         }// namespace emitters
     }// namespace commands


### PR DESCRIPTION
This adds spatial partitioning to drag and drop command emitter to optimise it.